### PR TITLE
feat: add buffer config

### DIFF
--- a/.github/workflows/check-go-task.yml
+++ b/.github/workflows/check-go-task.yml
@@ -118,6 +118,25 @@ jobs:
       - name: Check formatting
         run: git diff --color --exit-code
 
+  run-tests:
+    name: run-tests
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Run tests
+        run: task go:test
+
   check-config:
     name: check-config (${{ matrix.module.path }})
     runs-on: ubuntu-latest

--- a/.github/workflows/check-go-task.yml
+++ b/.github/workflows/check-go-task.yml
@@ -134,6 +134,12 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
 
+      - name: Install Task
+        uses: arduino/setup-task@v2
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: 3.x
+
       - name: Run tests
         run: task go:test
 

--- a/.github/workflows/check-go-task.yml
+++ b/.github/workflows/check-go-task.yml
@@ -124,6 +124,9 @@ jobs:
 
     strategy:
       fail-fast: false
+      matrix:
+        module:
+          - path: ./
 
     steps:
       - name: Checkout repository
@@ -141,6 +144,7 @@ jobs:
           version: 3.x
 
       - name: Run tests
+        working-directory: ${{ matrix.module.path }}
         run: task go:test
 
   check-config:

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 dist/
-
+coverage.out

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -147,3 +147,8 @@ tasks:
     desc: Format Go code
     cmds:
       - go fmt {{default .DEFAULT_GO_PACKAGES .GO_PACKAGES}}
+
+  go:test:
+    desc: Test Go code
+    cmds:
+      - go test -v -race -covermode=atomic -coverprofile=coverage.out ./...

--- a/buffering.go
+++ b/buffering.go
@@ -1,0 +1,184 @@
+//
+// This file is part of pluggable-monitor-protocol-handler.
+//
+// Copyright 2025 ARDUINO SA (http://www.arduino.cc/)
+//
+// This software is released under the GNU General Public License version 3,
+// which covers the main part of arduino-cli.
+// The terms of this license can be found at:
+// https://www.gnu.org/licenses/gpl-3.0.en.html
+//
+// You can be released from the requirements of the above licenses by purchasing
+// a commercial license. Buying such a license is mandatory if you want to modify or
+// otherwise use the software for commercial activities involving the Arduino
+// software without disclosing the source code of your own applications. To purchase
+// a commercial license, send an email to license@arduino.cc.
+//
+
+package monitor
+
+import (
+	"bytes"
+	"io"
+	"sync"
+	"time"
+)
+
+type BufferConfig struct {
+	HighWaterMark int           // >= 1
+	FlushInterval time.Duration // 0 to disable time-based flush
+	LineBuffering bool
+	// FlushQueueCapacity controls how many aggregated payloads can be queued for the TCP writer.
+	// If <= 0 a sensible default is applied.
+	FlushQueueCapacity int
+	// OverflowStrategy controls what to do if the queue is full when a flush happens.
+	// Supported values:
+	//   "drop"  (default)  -> drop the payload rather than blocking the port reader.
+	//   "wait"            -> wait up to OverflowWait duration for space, then drop if still full.
+	OverflowStrategy string
+	// OverflowWait is only used when OverflowStrategy == "wait". If <= 0, the behavior falls back to "drop".
+	OverflowWait time.Duration
+}
+
+func (c BufferConfig) normalized() BufferConfig {
+	cfg := c
+	if cfg.HighWaterMark < 1 {
+		cfg.HighWaterMark = 1
+	}
+	if cfg.FlushQueueCapacity <= 0 {
+		cfg.FlushQueueCapacity = 32
+	}
+	if cfg.OverflowStrategy == "" {
+		cfg.OverflowStrategy = "drop"
+	}
+	if cfg.OverflowWait < 0 {
+		cfg.OverflowWait = 0
+	}
+	return cfg
+}
+
+type Option func(*Server)
+
+func WithBufferConfig(cfg BufferConfig) Option {
+	return func(s *Server) {
+		s.bufCfg = cfg.normalized()
+	}
+}
+
+// internal aggregator used in port->conn pump
+type aggregator struct {
+	cfg    BufferConfig
+	mu     sync.Mutex
+	buf    bytes.Buffer
+	timer  *time.Timer
+	flushC chan []byte
+	closed bool
+}
+
+func newAggregator(cfg BufferConfig) *aggregator {
+	cfg = cfg.normalized()
+	return &aggregator{
+		cfg:    cfg,
+		flushC: make(chan []byte, cfg.FlushQueueCapacity),
+	}
+}
+
+func (a *aggregator) addChunk(p []byte) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	if a.closed {
+		return
+	}
+
+	if len(p) == 0 {
+		return
+	}
+	// append
+	a.buf.Write(p)
+
+	// schedule timer if needed and not running
+	if a.cfg.FlushInterval > 0 && a.timer == nil {
+		a.timer = time.AfterFunc(a.cfg.FlushInterval, a.onTimer)
+	}
+
+	// flush conditions
+	if a.buf.Len() >= a.cfg.HighWaterMark || (a.cfg.LineBuffering && bytes.Contains(p, []byte{'\n'})) {
+		a.flushLocked()
+	}
+}
+
+func (a *aggregator) onTimer() {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.flushLocked()
+}
+
+func (a *aggregator) flushLocked() {
+	if a.timer != nil {
+		a.timer.Stop()
+		a.timer = nil
+	}
+	if a.buf.Len() == 0 {
+		return
+	}
+	out := make([]byte, a.buf.Len())
+	copy(out, a.buf.Bytes())
+	a.buf.Reset()
+	switch a.cfg.OverflowStrategy {
+	case "wait":
+		// To avoid deadlocks, do not wait indefinitely while holding the mutex.
+		// We allow a bounded wait; after that, drop.
+		if a.cfg.OverflowWait <= 0 {
+			select {
+			case a.flushC <- out:
+			default:
+				// drop
+			}
+			return
+		}
+		deadline := time.NewTimer(a.cfg.OverflowWait)
+		defer deadline.Stop()
+		select {
+		case a.flushC <- out:
+		case <-deadline.C:
+			// drop after bounded wait
+		}
+	default: // "drop"
+		select {
+		case a.flushC <- out:
+		default:
+			// drop if consumer is slow
+		}
+	}
+}
+
+func (a *aggregator) drainTo(w io.Writer) error {
+	for payload := range a.flushC {
+		if len(payload) == 0 {
+			continue
+		}
+		if _, err := w.Write(payload); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (a *aggregator) close() {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.closed {
+		return
+	}
+	// Stop timer first to prevent future callbacks
+	if a.timer != nil {
+		a.timer.Stop()
+		a.timer = nil
+	}
+	// Flush any remaining data while the channel is still open
+	a.flushLocked()
+	// Now mark closed and close the channel
+	a.closed = true
+	close(a.flushC)
+}

--- a/buffering.go
+++ b/buffering.go
@@ -24,6 +24,10 @@ import (
 	"time"
 )
 
+// BufferConfig controls how bytes coming from the board (port) are aggregated
+// into larger chunks before being written to the TCP client. All fields are
+// optional; invalid or zero values are normalized to sensible defaults via
+// normalized().
 type BufferConfig struct {
 	HighWaterMark int           // >= 1
 	FlushInterval time.Duration // 0 to disable time-based flush
@@ -57,8 +61,11 @@ func (c BufferConfig) normalized() BufferConfig {
 	return cfg
 }
 
+// Option is a functional option used to configure a Server at construction time.
 type Option func(*Server)
 
+// WithBufferConfig sets the Server's buffering behavior. The provided cfg is
+// normalized (e.g., min values enforced) before being stored on the Server.
 func WithBufferConfig(cfg BufferConfig) Option {
 	return func(s *Server) {
 		s.bufCfg = cfg.normalized()

--- a/buffering_internal_test.go
+++ b/buffering_internal_test.go
@@ -1,0 +1,119 @@
+//
+// This file is part of pluggable-monitor-protocol-handler.
+//
+// Copyright 2025 ARDUINO SA (http://www.arduino.cc/)
+//
+// This software is released under the GNU General Public License version 3,
+// which covers the main part of arduino-cli.
+// The terms of this license can be found at:
+// https://www.gnu.org/licenses/gpl-3.0.en.html
+//
+// You can be released from the requirements of the above licenses by purchasing
+// a commercial license. Buying such a license is mandatory if you want to modify or
+// otherwise use the software for commercial activities involving the Arduino
+// software without disclosing the source code of your own applications. To purchase
+// a commercial license, send an email to license@arduino.cc.
+//
+
+package monitor
+
+import (
+	"testing"
+	"time"
+)
+
+// These tests exercise the aggregator's overflow behavior directly, without
+// going through the TCP server. We intentionally do NOT start drainTo(), so
+// the flush queue can fill up and trigger the configured strategy.
+
+func Test_Aggregator_Overflow_Drop(t *testing.T) {
+	cfg := BufferConfig{
+		HighWaterMark:      1, // flush every byte
+		FlushInterval:      0,
+		LineBuffering:      false,
+		FlushQueueCapacity: 1, // tiny queue to force overflow
+		OverflowStrategy:   "drop",
+	}
+	a := newAggregator(cfg)
+
+	// Push a burst of bytes quickly; with capacity=1 and no consumer, only the
+	// first payload can be queued, the rest should be dropped.
+	for i := 0; i < 50; i++ {
+		a.addChunk([]byte{'a' + byte(i%26)})
+	}
+	// close will try a final flush; with a full queue and strategy=drop, it drops too.
+	a.close()
+
+	// Drain whatever remained in the queue and count.
+	total := 0
+	count := 0
+	for p := range a.flushC {
+		count++
+		total += len(p)
+	}
+
+	if count > 1 { // capacity is 1, so at most 1 payload can remain queued
+		t.Fatalf("expected at most 1 queued payload, got %d", count)
+	}
+	if total >= 50 { // we queued 50 bytes, but nearly all should be dropped
+		t.Fatalf("expected drops with strategy=drop; total delivered=%d", total)
+	}
+}
+
+func Test_Aggregator_Overflow_Wait(t *testing.T) {
+	cfg := BufferConfig{
+		HighWaterMark:      1,
+		FlushInterval:      0,
+		LineBuffering:      false,
+		FlushQueueCapacity: 1,
+		OverflowStrategy:   "wait",
+		OverflowWait:       25 * time.Millisecond,
+	}
+	a := newAggregator(cfg)
+
+	start := time.Now()
+	for i := 0; i < 3; i++ {
+		a.addChunk([]byte{'x'}) // first enqueues; next two wait ~OverflowWait then drop
+	}
+	a.close()
+	elapsed := time.Since(start)
+
+	// Drain queue and count payloads
+	count := 0
+	for range a.flushC {
+		count++
+	}
+	if count != 1 {
+		t.Fatalf("expected exactly 1 queued payload with capacity=1 and no consumer; got %d", count)
+	}
+
+	// We called addChunk 3 times; with OverflowWait=25ms, we expect ~50ms waiting.
+	// Allow slack for CI.
+	if elapsed < 40*time.Millisecond {
+		t.Fatalf("expected bounded waiting to take noticeable time; elapsed=%v (<40ms)", elapsed)
+	}
+}
+
+func Test_Aggregator_QueueCapacity(t *testing.T) {
+	cfg := BufferConfig{
+		HighWaterMark:      1,
+		FlushInterval:      0,
+		LineBuffering:      false,
+		FlushQueueCapacity: 3, // allow a few in-flight payloads
+		OverflowStrategy:   "drop",
+	}
+	a := newAggregator(cfg)
+
+	for i := 0; i < 10; i++ {
+		a.addChunk([]byte{'A' + byte(i%26)})
+	}
+	a.close()
+
+	count := 0
+	for range a.flushC {
+		count++
+	}
+	if count > 3 {
+		t.Fatalf("expected at most queue capacity (3) payloads, got %d", count)
+	}
+}

--- a/monitor_test.go
+++ b/monitor_test.go
@@ -1,0 +1,696 @@
+//
+// This file is part of pluggable-monitor-protocol-handler.
+//
+// Copyright 2025 ARDUINO SA (http://www.arduino.cc/)
+//
+// This software is released under the GNU General Public License version 3,
+// which covers the main part of arduino-cli.
+// The terms of this license can be found at:
+// https://www.gnu.org/licenses/gpl-3.0.en.html
+//
+// You can be released from the requirements of the above licenses by purchasing
+// a commercial license. Buying such a license is mandatory if you want to modify or
+// otherwise use the software for commercial activities involving the Arduino
+// software without disclosing the source code of your own applications. To purchase
+// a commercial license, send an email to license@arduino.cc.
+//
+
+package monitor_test
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
+	"net"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	monitor "github.com/arduino/pluggable-monitor-protocol-handler"
+)
+
+// sample records a received byte and its arrival time for timing checks.
+type sample struct {
+	t time.Time
+	b byte
+}
+
+// lockBuf is a threadsafe bytes.Buffer used to avoid data races when the server
+// writes status lines while tests may read them.
+type lockBuf struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (w *lockBuf) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.buf.Write(p)
+}
+
+func (w *lockBuf) String() string {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.buf.String()
+}
+
+// testPort is a controllable io.ReadWriter. Writes push into a channel;
+// Reads pop one message at a time (no buffering).
+type testPort struct {
+	in  chan []byte // bytes written by server go to this channel (Tx to board)
+	out chan []byte // bytes we want the server to read (Rx from board)
+}
+
+func newTestPort() *testPort {
+	return &testPort{
+		in:  make(chan []byte, 128),
+		out: make(chan []byte, 128),
+	}
+}
+
+func (p *testPort) Read(b []byte) (int, error) {
+	data, ok := <-p.out
+	if !ok {
+		return 0, io.EOF
+	}
+	n := copy(b, data)
+	return n, nil
+}
+
+func (p *testPort) Write(b []byte) (int, error) {
+	// Forward what the client wrote to the board into the in-chan
+	cp := make([]byte, len(b))
+	copy(cp, b)
+	p.in <- cp
+	return len(b), nil
+}
+
+// dummy monitor that returns our testPort and can inject errors
+type dummyMon struct {
+	port          *testPort
+	describeErr   error
+	configureErr  error
+	configureSeen [][2]string
+	openErr       error
+	closeErr      error
+	helloErr      error
+}
+
+func (d *dummyMon) Hello(_ string, _ int) error { return d.helloErr }
+func (d *dummyMon) Describe() (*monitor.PortDescriptor, error) {
+	if d.describeErr != nil {
+		return nil, d.describeErr
+	}
+	return &monitor.PortDescriptor{}, nil
+}
+func (d *dummyMon) Configure(name, value string) error {
+	d.configureSeen = append(d.configureSeen, [2]string{name, value})
+	return d.configureErr
+}
+func (d *dummyMon) Open(_ string) (io.ReadWriter, error) {
+	if d.openErr != nil {
+		return nil, d.openErr
+	}
+	return d.port, nil
+}
+func (d *dummyMon) Close() error { return d.closeErr }
+func (d *dummyMon) Quit()        {}
+
+func startTCP(t *testing.T) (addr string, connCh chan net.Conn, closeFn func()) {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	connCh = make(chan net.Conn, 1)
+	go func() {
+		c, _ := ln.Accept()
+		connCh <- c
+	}()
+	addr = ln.Addr().String()
+	closeFn = func() { _ = ln.Close() }
+	return
+}
+
+func runServer(t *testing.T, mon monitor.Monitor, input string) (getOut func() string, stop func()) {
+	t.Helper()
+	srv := monitor.NewServer(mon)
+	in := bytes.NewBufferString(input)
+	out := &lockBuf{}
+	done := make(chan struct{})
+	go func() {
+		_ = srv.Run(in, out)
+		close(done)
+	}()
+	return out.String, func() { <-done }
+}
+
+func readBytesWithTimestamps(t *testing.T, c net.Conn, want int, perReadDeadline, totalDeadline time.Duration) []sample {
+	t.Helper()
+	var got []sample
+	br := bufio.NewReader(c)
+	end := time.Now().Add(totalDeadline)
+	for time.Now().Before(end) && len(got) < want {
+		_ = c.SetReadDeadline(time.Now().Add(perReadDeadline))
+		b, err := br.ReadByte()
+		if err == nil {
+			got = append(got, sample{t: time.Now(), b: b})
+		}
+	}
+	return got
+}
+
+// gapsStats classifies inter-arrival gaps: near-zero (<5ms), big (>12ms), and tracks
+// the maximum run of consecutive near-zero gaps (indicative of chunk size - 1).
+func gapsStats(samples []sample) (nearZero, big, maxConsecNearZero int) {
+	const near = 5 * time.Millisecond
+	const bigGap = 12 * time.Millisecond
+	consec := 0
+	for i := 1; i < len(samples); i++ {
+		d := samples[i].t.Sub(samples[i-1].t)
+		if d < near {
+			nearZero++
+			consec++
+			if consec > maxConsecNearZero {
+				maxConsecNearZero = consec
+			}
+		} else {
+			consec = 0
+			if d > bigGap {
+				big++
+			}
+		}
+	}
+	return
+}
+
+func bytesFrom(s []sample) string {
+	out := make([]byte, len(s))
+	for i := range s {
+		out[i] = s[i].b
+	}
+	return string(out)
+}
+
+func Test_Unbuffered_PortToTCP_ForwardsImmediately(t *testing.T) {
+	t.Parallel()
+
+	port := newTestPort()
+	mon := &dummyMon{port: port}
+
+	addr, connCh, closeTCP := startTCP(t)
+	defer closeTCP()
+
+	cmds := strings.Join([]string{
+		`HELLO 1 "test"`,
+		fmt.Sprintf("OPEN %s dev", addr),
+	}, "\n") + "\n"
+	getOut, stop := runServer(t, mon, cmds)
+	defer stop()
+
+	var accepted net.Conn
+	select {
+	case accepted = <-connCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("did not accept TCP connection")
+	}
+
+	go func() {
+		for _, ch := range []byte("hallo\r\n") {
+			port.out <- []byte{ch}
+			time.Sleep(10 * time.Millisecond)
+		}
+	}()
+
+	var got []sample
+	br := bufio.NewReader(accepted)
+	readDeadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(readDeadline) && len(got) < 7 {
+		_ = accepted.SetReadDeadline(time.Now().Add(200 * time.Millisecond))
+		b, err := br.ReadByte()
+		if err == nil {
+			got = append(got, sample{t: time.Now(), b: b})
+		}
+	}
+
+	if len(got) != 7 {
+		t.Fatalf("expected 7 bytes, got %d (%q)\nstdout:\n%s", len(got), bytesFrom(got), getOut())
+	}
+
+	var coalesced int
+	for i := 1; i < len(got); i++ {
+		d := got[i].t.Sub(got[i-1].t)
+		if d < 5*time.Millisecond {
+			coalesced++
+		}
+	}
+	if coalesced >= 3 {
+		t.Fatalf("observed %d near-zero gaps (<5ms) -> likely batching/coalescing; want spaced forwarding. bytes=%q",
+			coalesced, bytesFrom(got))
+	}
+}
+
+func Test_TCPToPort_WritesForwarded(t *testing.T) {
+	t.Parallel()
+
+	port := newTestPort()
+	mon := &dummyMon{port: port}
+
+	addr, connCh, closeTCP := startTCP(t)
+	defer closeTCP()
+
+	cmds := strings.Join([]string{
+		`HELLO 1 "test"`,
+		fmt.Sprintf("OPEN %s dev", addr),
+	}, "\n") + "\n"
+	_, stop := runServer(t, mon, cmds)
+	defer stop()
+
+	var conn net.Conn
+	select {
+	case conn = <-connCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("did not accept TCP connection")
+	}
+
+	want := []byte("abc\r\ndef\n")
+	_, _ = conn.Write([]byte("abc\r\n"))
+	time.Sleep(5 * time.Millisecond)
+	_, _ = conn.Write([]byte("def\n"))
+
+	deadline := time.Now().Add(2 * time.Second)
+	var got []byte
+	for time.Now().Before(deadline) && len(got) < len(want) {
+		select {
+		case chunk := <-port.in:
+			got = append(got, chunk...)
+		case <-time.After(50 * time.Millisecond):
+		}
+	}
+	if string(got) != string(want) {
+		t.Fatalf("port did not receive expected bytes. got=%q want=%q", string(got), string(want))
+	}
+}
+
+func Test_Buffer_HighWaterMark_Only(t *testing.T) {
+	t.Parallel()
+
+	port := newTestPort()
+	mon := &dummyMon{port: port}
+
+	addr, connCh, closeTCP := startTCP(t)
+	defer closeTCP()
+
+	cmds := strings.Join([]string{
+		`HELLO 1 "test"`,
+		`CONFIGURE _buffer.hwm 10`,
+		fmt.Sprintf("OPEN %s dev", addr),
+	}, "\n") + "\n"
+	_, stop := runServer(t, mon, cmds)
+	defer stop()
+
+	var accepted net.Conn
+	select {
+	case accepted = <-connCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("did not accept TCP connection")
+	}
+
+	payload := []byte("abcdefghijklmnopqrstuvwxyz")[:25]
+	go func() {
+		for _, ch := range payload {
+			port.out <- []byte{ch}
+			time.Sleep(5 * time.Millisecond)
+		}
+		close(port.out)
+	}()
+
+	got := readBytesWithTimestamps(t, accepted, len(payload), 200*time.Millisecond, 2*time.Second)
+	if len(got) != len(payload) {
+		t.Fatalf("expected %d bytes, got %d (%q)", len(payload), len(got), bytesFrom(got))
+	}
+
+	near, big, maxRun := gapsStats(got)
+	if big < 2 {
+		t.Fatalf("expected >=2 big inter-chunk gaps with HWM-only, got %d; bytes=%q", big, bytesFrom(got))
+	}
+	if maxRun < 7 {
+		t.Fatalf("expected large coalesced runs (>=7) with HWM-only, got maxRun=%d; bytes=%q (near=%d,big=%d)", maxRun, bytesFrom(got), near, big)
+	}
+}
+
+func Test_Buffer_Line_Only(t *testing.T) {
+	t.Parallel()
+
+	port := newTestPort()
+	mon := &dummyMon{port: port}
+
+	addr, connCh, closeTCP := startTCP(t)
+	defer closeTCP()
+
+	cmds := strings.Join([]string{
+		`HELLO 1 "test"`,
+		`CONFIGURE _buffer.hwm 1024`,
+		`CONFIGURE _buffer.line true`,
+		fmt.Sprintf("OPEN %s dev", addr),
+	}, "\n") + "\n"
+	_, stop := runServer(t, mon, cmds)
+	defer stop()
+
+	var accepted net.Conn
+	select {
+	case accepted = <-connCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("did not accept TCP connection")
+	}
+
+	line := []byte("hello, world\n")
+	go func() {
+		for _, ch := range line {
+			port.out <- []byte{ch}
+			time.Sleep(5 * time.Millisecond)
+		}
+	}()
+
+	got := readBytesWithTimestamps(t, accepted, len(line), 200*time.Millisecond, 2*time.Second)
+	if len(got) != len(line) {
+		t.Fatalf("expected %d bytes, got %d (%q)", len(line), len(got), bytesFrom(got))
+	}
+
+	_, big, maxRun := gapsStats(got)
+	if big != 0 {
+		t.Fatalf("expected 0 big gaps with line-buffering, got %d; bytes=%q", big, bytesFrom(got))
+	}
+	if maxRun < len(line)-1-2 {
+		t.Fatalf("expected near-complete coalescing with line-buffering, got maxRun=%d; bytes=%q", maxRun, bytesFrom(got))
+	}
+}
+
+func Test_Buffer_Interval_Only(t *testing.T) {
+	t.Parallel()
+
+	port := newTestPort()
+	mon := &dummyMon{port: port}
+
+	addr, connCh, closeTCP := startTCP(t)
+	defer closeTCP()
+
+	cmds := strings.Join([]string{
+		`HELLO 1 "test"`,
+		`CONFIGURE _buffer.hwm 1024`,
+		`CONFIGURE _buffer.interval_ms 16`,
+		fmt.Sprintf("OPEN %s dev", addr),
+	}, "\n") + "\n"
+	_, stop := runServer(t, mon, cmds)
+	defer stop()
+
+	var accepted net.Conn
+	select {
+	case accepted = <-connCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("did not accept TCP connection")
+	}
+
+	payload := []byte("abcdefghijklmnopqrstuvwx")
+	go func() {
+		for _, ch := range payload {
+			port.out <- []byte{ch}
+			time.Sleep(5 * time.Millisecond)
+		}
+		close(port.out)
+	}()
+
+	got := readBytesWithTimestamps(t, accepted, len(payload), 200*time.Millisecond, 2*time.Second)
+	if len(got) != len(payload) {
+		t.Fatalf("expected %d bytes, got %d (%q)", len(payload), len(got), bytesFrom(got))
+	}
+
+	near, big, maxRun := gapsStats(got)
+	if big < 2 {
+		t.Fatalf("expected several big gaps with interval-only, got %d; bytes=%q", big, bytesFrom(got))
+	}
+	if maxRun < 1 || maxRun > 5 {
+		t.Fatalf("expected small coalesced groups (1..5) with interval-only, got maxRun=%d; bytes=%q (near=%d,big=%d)", maxRun, bytesFrom(got), near, big)
+	}
+}
+
+func Test_Buffer_Invalid_HWM_LeavesUnbuffered(t *testing.T) {
+	t.Parallel()
+
+	port := newTestPort()
+	mon := &dummyMon{port: port}
+
+	addr, connCh, closeTCP := startTCP(t)
+	defer closeTCP()
+
+	cmds := strings.Join([]string{
+		`HELLO 1 "test"`,
+		`CONFIGURE _buffer.hwm -1`,
+		`CONFIGURE _buffer.interval_ms 0`,
+		`CONFIGURE _buffer.line false`,
+		fmt.Sprintf("OPEN %s dev", addr),
+	}, "\n") + "\n"
+	_, stop := runServer(t, mon, cmds)
+	defer stop()
+
+	var accepted net.Conn
+	select {
+	case accepted = <-connCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("did not accept TCP connection")
+	}
+
+	go func() {
+		for _, ch := range []byte("hallo\r\n") {
+			port.out <- []byte{ch}
+			time.Sleep(10 * time.Millisecond)
+		}
+	}()
+
+	got := readBytesWithTimestamps(t, accepted, 7, 200*time.Millisecond, 2*time.Second)
+	if len(got) != 7 {
+		t.Fatalf("expected 7 bytes, got %d (%q)", len(got), bytesFrom(got))
+	}
+
+	near, _, _ := gapsStats(got)
+	if near >= 5 {
+		t.Fatalf("expected unbuffered behavior after invalid HWM; near-zero gaps=%d bytes=%q", near, bytesFrom(got))
+	}
+}
+
+func Test_Buffer_Invalid_LineValue_DoesNotEnableLineBuffering(t *testing.T) {
+	t.Parallel()
+
+	port := newTestPort()
+	mon := &dummyMon{port: port}
+
+	addr, connCh, closeTCP := startTCP(t)
+	defer closeTCP()
+
+	cmds := strings.Join([]string{
+		`HELLO 1 "test"`,
+		`CONFIGURE _buffer.hwm 1024`,
+		`CONFIGURE _buffer.interval_ms 0`,
+		`CONFIGURE _buffer.line maybe`,
+		fmt.Sprintf("OPEN %s dev", addr),
+	}, "\n") + "\n"
+	_, stop := runServer(t, mon, cmds)
+	defer stop()
+
+	var accepted net.Conn
+	select {
+	case accepted = <-connCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("did not accept TCP connection")
+	}
+
+	line := []byte("hello, world\n")
+	go func() {
+		for _, ch := range line {
+			port.out <- []byte{ch}
+			time.Sleep(10 * time.Millisecond)
+		}
+	}()
+
+	got := readBytesWithTimestamps(t, accepted, len(line), 200*time.Millisecond, 1*time.Second)
+	if len(got) != 0 {
+		t.Fatalf("expected 0 bytes without EOF or timer when line buffering is invalid; got %d (%q)", len(got), bytesFrom(got))
+	}
+}
+
+func Test_CommandBeforeHelloErrors(t *testing.T) {
+	in := strings.Join([]string{`DESCRIBE`, `QUIT`}, "\n") + "\n"
+	m := &dummyMon{port: newTestPort()}
+	getOut, stop := runServer(t, m, in)
+	stop()
+	out := getOut()
+	if !strings.Contains(out, `"eventType": "command_error"`) || !strings.Contains(out, "First command must be HELLO") {
+		t.Fatalf("expected not-initialized error, got:\n%s", out)
+	}
+}
+
+func Test_Hello_Invalid_And_Duplicate(t *testing.T) {
+	in := strings.Join([]string{`HELLO x "ua"`, `HELLO 1 "ua"`, `QUIT`}, "\n") + "\n"
+	m := &dummyMon{port: newTestPort()}
+	getOut, stop := runServer(t, m, in)
+	stop()
+	out := getOut()
+	if !strings.Contains(out, `"eventType": "hello"`) || !strings.Contains(out, "Invalid HELLO command") || !strings.Contains(out, `"error": true`) {
+		t.Fatalf("expected invalid version error, got:\n%s", out)
+	}
+	if !strings.Contains(out, `"eventType": "hello"`) || !strings.Contains(out, `"message": "OK"`) {
+		t.Fatalf("expected successful hello after invalid, got:\n%s", out)
+	}
+	if strings.Count(out, `"eventType": "hello"`) < 1 {
+		t.Fatalf("expected exactly one successful hello, got:\n%s", out)
+	}
+}
+
+func Test_Describe_Error(t *testing.T) {
+	m := &dummyMon{port: newTestPort(), describeErr: fmt.Errorf("boom")}
+	in := strings.Join([]string{`HELLO 1 "ua"`, `DESCRIBE`, `QUIT`}, "\n") + "\n"
+	getOut, stop := runServer(t, m, in)
+	stop()
+	out := getOut()
+	if !strings.Contains(out, `"eventType": "describe"`) || !strings.Contains(out, `"error": true`) || !strings.Contains(out, "boom") {
+		t.Fatalf("expected describe error, got:\n%s", out)
+	}
+}
+
+func Test_Configure_Forward_And_InvalidInterval(t *testing.T) {
+	m := &dummyMon{port: newTestPort()}
+	in := strings.Join([]string{
+		`HELLO 1 "ua"`,
+		`CONFIGURE foo bar`,
+		`CONFIGURE _buffer.interval_ms -5`,
+		`QUIT`,
+	}, "\n") + "\n"
+	getOut, stop := runServer(t, m, in)
+	stop()
+	out := getOut()
+	if len(m.configureSeen) == 0 || m.configureSeen[0][0] != "foo" || m.configureSeen[0][1] != "bar" {
+		t.Fatalf("expected CONFIGURE to reach impl; seen=%v", m.configureSeen)
+	}
+	if !strings.Contains(out, "invalid _buffer.interval_ms") {
+		t.Fatalf("expected invalid interval error, got:\n%s", out)
+	}
+}
+
+func Test_Open_Invalid_And_DialFail(t *testing.T) {
+	m := &dummyMon{port: newTestPort()}
+	in := strings.Join([]string{
+		`HELLO 1 "ua"`,
+		`OPEN only-one-token`,
+		`OPEN 127.0.0.1:1 dev`,
+		`QUIT`,
+	}, "\n") + "\n"
+	getOut, stop := runServer(t, m, in)
+	stop()
+	out := getOut()
+	if !strings.Contains(out, `Invalid OPEN command`) {
+		t.Fatalf("expected invalid OPEN error, got:\n%s", out)
+	}
+	if !(strings.Contains(out, "dial tcp") || strings.Contains(out, "connect: connection refused") || strings.Contains(out, "refused") || strings.Contains(out, "connect")) {
+		// allow platform/Go version specific wording
+		t.Fatalf("expected dial/connect error, got:\n%s", out)
+	}
+}
+
+func Test_Close_Errors_And_OK(t *testing.T) {
+	// 1) close without open
+	m1 := &dummyMon{port: newTestPort()}
+	in1 := strings.Join([]string{`HELLO 1 "ua"`, `CLOSE`, `QUIT`}, "\n") + "\n"
+	get1, stop1 := runServer(t, m1, in1)
+	stop1()
+	if !strings.Contains(get1(), `port already closed`) {
+		t.Fatalf("expected 'port already closed' error, got:\n%s", get1())
+	}
+
+	// 2) close after open with impl error
+	addr, connCh, closeTCP := startTCP(t)
+	defer closeTCP()
+	m2 := &dummyMon{port: newTestPort(), closeErr: fmt.Errorf("impl close failed")}
+	in2 := strings.Join([]string{`HELLO 1 "ua"`, fmt.Sprintf("OPEN %s dev", addr), `CLOSE`, `QUIT`}, "\n") + "\n"
+	get2, stop2 := runServer(t, m2, in2)
+	select {
+	case <-connCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("did not accept TCP connection")
+	}
+	stop2()
+	out := get2()
+	if !strings.Contains(out, `"eventType": "close"`) || !strings.Contains(out, `"error": true`) || !strings.Contains(out, "impl close failed") {
+		t.Fatalf("expected close error due to impl, got:\n%s", out)
+	}
+}
+
+func Test_Quit_EndsServer(t *testing.T) {
+	m := &dummyMon{port: newTestPort()}
+	in := strings.Join([]string{`HELLO 1 "ua"`, `QUIT`}, "\n") + "\n"
+	_, stop := runServer(t, m, in)
+	stop()
+}
+
+func Test_Unknown_Command_Errors(t *testing.T) {
+	m := &dummyMon{port: newTestPort()}
+	in := strings.Join([]string{`HELLO 1 "ua"`, `FOO`, `QUIT`}, "\n") + "\n"
+	getOut, stop := runServer(t, m, in)
+	stop()
+	out := getOut()
+	if !strings.Contains(out, `"eventType": "command_error"`) || !strings.Contains(out, "Command FOO not supported") {
+		t.Fatalf("expected command_error for unknown command, got:\n%s", out)
+	}
+}
+
+func Test_Hello_ImplError(t *testing.T) {
+	m := &dummyMon{port: newTestPort(), helloErr: fmt.Errorf("boom from impl")}
+	in := strings.Join([]string{`HELLO 1 "ua"`, `QUIT`}, "\n") + "\n"
+	getOut, stop := runServer(t, m, in)
+	stop()
+	out := getOut()
+	if !strings.Contains(out, `"eventType": "hello"`) || !strings.Contains(out, `"error": true`) || !strings.Contains(out, "boom from impl") {
+		t.Fatalf("expected hello error from impl, got:\n%s", out)
+	}
+}
+
+func Test_Buffer_Config_NewKeys_OK(t *testing.T) {
+	m := &dummyMon{port: newTestPort()}
+	in := strings.Join([]string{
+		`HELLO 1 "ua"`,
+		`CONFIGURE _buffer.queue 64`,
+		`CONFIGURE _buffer.overflow wait`,
+		`CONFIGURE _buffer.overflow_wait_ms 50`,
+		`QUIT`,
+	}, "\n") + "\n"
+	getOut, stop := runServer(t, m, in)
+	stop()
+	out := getOut()
+	if strings.Count(out, `"eventType": "configure"`) < 3 {
+		t.Fatalf("expected 3 configure OK responses, got:\n%s", out)
+	}
+}
+
+func Test_Buffer_Config_NewKeys_Invalid(t *testing.T) {
+	m := &dummyMon{port: newTestPort()}
+	in := strings.Join([]string{
+		`HELLO 1 "ua"`,
+		`CONFIGURE _buffer.queue 0`,
+		`CONFIGURE _buffer.overflow nope`,
+		`CONFIGURE _buffer.overflow_wait_ms -1`,
+		`QUIT`,
+	}, "\n") + "\n"
+	getOut, stop := runServer(t, m, in)
+	stop()
+	out := getOut()
+	for _, want := range []string{
+		"invalid _buffer.queue",
+		"invalid _buffer.overflow",
+		"invalid _buffer.overflow_wait_ms",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("expected error %q in output, got:\n%s", want, out)
+		}
+	}
+}


### PR DESCRIPTION
This PR is mainly to start a discussion with the Arduino CLI team about whether handler-level buffering is the right approach. I do not really know these things, but I would like to use them downstream. Thank you!

What
 - Adds opt-in buffering on the port→TCP path.
 - Default behavior stays unbuffered.
 - Uses a small queue with an overflow policy (drop or bounded wait).
 - No API break: controlled via CONFIGURE keys.

CONFIGURE keys (defaults)
 - `_buffer.hwm` n>=1 (1) – size trigger
 - `_buffer.interval_ms` ms>=0 (0) – time trigger (0 = disabled)
 - `_buffer.line` true|false|on|off|0|1 (false) – flush on \n
 - `_buffer.queue` n>=1 (32) – queued payloads between aggregator and TCP writer
 - `_buffer.overflow` <drop|wait> (drop) – on full queue
 - `_buffer.overflow_wait_ms` ms>=0 (0) – wait budget when overflow=wait

Ref: arduino/pluggable-monitor-protocol-handler#33
Arduino CLI: arduino/arduino-cli#2975